### PR TITLE
[chore] make details tab default on theme details

### DIFF
--- a/www/src/pages/themes/Product.js
+++ b/www/src/pages/themes/Product.js
@@ -15,7 +15,7 @@ import april from './april.jpg'
 // http://www.mojomarketplace.com/item/pav-styleshop-responsive-opencart-2-0-themes
 // Similar to this without shifting upwards, use a gray background
 class Product extends React.Component {
-  state = { activeItem: 'home' }
+  state = { activeItem: 'details' }
 
   handleItemClick = (e, { name }) => this.setState({ activeItem: name })
 


### PR DESCRIPTION
The details tab is the default view when a user clicks a theme from the
home page.