### PR TITLE
[feat] add Docker support for www

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # babylon
 open source marketplace framework
+
+
+# Workflow
+Local development can occur in the following environments.
+
+## development environment
+- `docker-compose -p babylon_dev -f docker-compose/dev.yaml up`
+
+Builds a image suite for local dev with live reload server (create-react-app)
+to watch for code changes.
+
+## production environment
+- `docker-compose -p babylon_prod -f docker-compose/prod.yaml up --build`
+
+Builds a local version of the production ready image suite.

--- a/docker-compose/dev.yaml
+++ b/docker-compose/dev.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  www:
+    build:
+      context: ../www
+      dockerfile: Dockerfile.dev
+    ports:
+      - 3000:3000
+    volumes:
+      - ../www:/usr/src/app

--- a/docker-compose/prod.yaml
+++ b/docker-compose/prod.yaml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  www:
+    build:
+      context: ../www
+      dockerfile: Dockerfile.prod
+    ports:
+     - 8080:80

--- a/www/Dockerfile.dev
+++ b/www/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node:9.7.1
+WORKDIR /usr/src/app
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./usr/src/app
+RUN yarn
+
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/www/Dockerfile.prod
+++ b/www/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM node:9.7.1 as build
+WORKDIR /usr/src/app
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./
+RUN yarn build
+
+# Stage 2 - the production environment
+FROM nginx:1.12-alpine
+COPY --from=build /usr/src/app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Project supports builds images for localt development using
docker-compose. The dev image has live reload capabilities. The prod
image deploys the app to an nginx server.