### PR TITLE
[feat] add server and db docker services

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ to watch for code changes.
 - `docker-compose -p babylon_prod -f docker-compose/prod.yaml up --build`
 
 Builds a local version of the production ready image suite.
+
+## Connect to existing containers
+If you want to connect to an existing, running container use:
+- `$ docker exec -it <CONTAINER_NAME> <COMMAND>`
+
+Examples:
+
+Connect to the database container to inspect database
+- `$ docker exec -it mongo_db mongo`

--- a/docker-compose/dev.yaml
+++ b/docker-compose/dev.yaml
@@ -1,6 +1,8 @@
 version: '3.6'
 services:
+
   www:
+    container_name: babylon_www
     build:
       context: ../www
       dockerfile: Dockerfile.dev
@@ -8,3 +10,27 @@ services:
       - 3000:3000
     volumes:
       - ../www:/usr/src/app
+
+  server:
+    container_name: babylon_server
+    build:
+      context: ../server
+      dockerfile: Dockerfile.dev
+    restart: always
+    ports:
+      - 5000:5000
+    volumes:
+      - ../server:/usr/src/app
+    links:
+      - db
+
+  db:
+    container_name: mongo_db
+    image: mongo
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - 27017:27017
+
+volumes:
+  mongo-data:

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,0 +1,11 @@
+# server
+FROM node:9.7.1
+
+WORKDIR /usr/src/app
+
+COPY package.json yarn.lock ./
+RUN yarn
+COPY . ./usr/src/app
+
+EXPOSE 5000
+CMD ["npm", "start"]

--- a/server/config.js
+++ b/server/config.js
@@ -5,7 +5,7 @@ module.exports = {
   appName: 'Rocket Rides',
 
   // Server port.
-  port: 3000,
+  port: 5000,
 
   // Secret for cookie sessions.
   secret: 'YOUR_SECRET',
@@ -23,7 +23,7 @@ module.exports = {
 
   // Configuration for MongoDB.
   mongo: {
-    uri: 'mongodb://localhost/rocketrides'
+    uri: 'mongodb://db/rocketrides'
   },
 
   // Configuration for Google Cloud (only useful if you want to deploy to GCP).


### PR DESCRIPTION
Use Docker Compose to create an express service as well as
a mongodb service which can communicate with eachother through
shared data volumes and container host names.

Container suite is for local development.